### PR TITLE
Fix/proxy tcptransport waiting state

### DIFF
--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -115,7 +115,9 @@ public class TCPTransport: Transport {
             case .ready:
                 self?.removeTimeoutTimer()
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting(let error), .failed(let error):
+            case .waiting(let error):
+                self?.delegate?.connectionChanged(state: .waiting(error))
+            case .failed(let error):
                 self?.delegate?.connectionChanged(state: .failed(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)

--- a/Starscream.podspec
+++ b/Starscream.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Starscream"
-  s.version      = "4.0.11"
+  s.version      = "4.0.12"
   s.summary      = "A conforming WebSocket RFC 6455 client library in Swift."
   s.homepage     = "https://github.com/daltoniam/Starscream"
   s.license      = 'Apache License, Version 2.0'


### PR DESCRIPTION
Proxy the `.waiting` state through the `TCPTransport` instead of routing it to the `.failed` state.